### PR TITLE
Update: Series name leveraging Grafana label defaults

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import defaults from 'lodash/defaults';
-import { BracesPlugin, QueryField, Select, Field, Input, Collapse } from '@grafana/ui';
+import { BracesPlugin, QueryField, Select, InlineField, Input } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from './datasource';
 import { defaultQuery, LightstepDataSourceOptions, LightstepQuery } from './types';
@@ -85,18 +85,18 @@ export class QueryEditor extends PureComponent<Props, QueryEditorState> {
     });
     return (
       <div>
-        <div className="gf-form">
-          {this.state.projects.length > 1 && (
-            <Select
-              options={projectNameOptions}
-              value={this.props.query.projectName}
-              menuPlacement="bottom"
-              onChange={this.onProjectSelectionChange}
-              isSearchable={false}
-              width={20}
-            />
-          )}
+        {this.state.projects.length > 1 && (
+          <Select
+            options={projectNameOptions}
+            value={this.props.query.projectName}
+            menuPlacement="bottom"
+            onChange={this.onProjectSelectionChange}
+            isSearchable={false}
+            width={20}
+          />
+        )}
 
+        <InlineField grow label="Query" labelWidth={15}>
           <QueryField
             query={query.text}
             portalOrigin="lightstep"
@@ -105,28 +105,21 @@ export class QueryEditor extends PureComponent<Props, QueryEditorState> {
             onChange={this.onQueryChange}
             onRunQuery={this.props.onRunQuery}
           />
-        </div>
-        <div className="gf-form">
-          <Collapse
-            collapsible
-            label="Options"
-            isOpen={this.state.isOptionsOpen}
-            onToggle={() => this.setState({ isOptionsOpen: !this.state.isOptionsOpen })}
-          >
-            <Field
-              label="Legend"
-              description="Series name override or template. Ex. {{hostname}} will be replaced with label value for hostname."
-            >
-              <Input
-                css
-                name="legendFormat"
-                spellCheck="false"
-                onChange={this.onChangeFormat}
-                value={this.props.query.format}
-              />
-            </Field>
-          </Collapse>
-        </div>
+        </InlineField>
+        <InlineField
+          grow
+          label="Series name"
+          labelWidth={15}
+          tooltip="Series name displayed in the legend. Interpolation of variables supported with 'Variable syntax', eg $varname."
+        >
+          <Input
+            css
+            name="legendFormat"
+            spellCheck="false"
+            onChange={this.onChangeFormat}
+            value={this.props.query.format}
+          />
+        </InlineField>
       </div>
     );
   }


### PR DESCRIPTION

## What this PR does

Addresses a number of usability problems with series names by fixing the legend field.

## Current UX

Series names are displayed depending on whether they have any group by values, if a query has none then the complete query is displayed as the series name. If there are are group by values they're used as the series name:

#### Single query with no group by

<img width="1645" alt="image" src="https://user-images.githubusercontent.com/8461733/226513632-a887800d-09c0-4267-8107-7c1b7b4844eb.png">

#### Single query with group by values

<img width="1646" alt="image" src="https://user-images.githubusercontent.com/8461733/226513679-5b5a1b24-663c-44b5-befa-7e5fe93d1502.png">

## UX problems

This pattern begins to become problematic in a few places:

1 - For long single queries (like joins) the entire query is used for the series name which can be noisy

<img width="1643" alt="image" src="https://user-images.githubusercontent.com/8461733/226513881-f0425b13-a97f-4560-b16a-ed6b76e455f8.png">

2 - Multiple queries don't have any indicator of which query each series belongs to, in charts like this one it's possible to end up with two **distinct** metrics that have the same label names

<img width="1646" alt="image" src="https://user-images.githubusercontent.com/8461733/226514051-e69b10ef-6349-46e0-b687-2e0706f7c244.png">

3 - Attempting to add series names with the legend input doesn't work as expected

![2023-03-20 20 28 44](https://user-images.githubusercontent.com/8461733/226514184-a3a530f1-e126-42c9-a0d9-0c63fbbbce6a.gif)

![2023-03-20 21 01 21](https://user-images.githubusercontent.com/8461733/226514581-d7cd9905-ba10-4f89-b283-9a84cf6ff5e1.gif)

## Proposed change

This PR aligns the plugin closer to the Grafana out of the box support by passing the query label values to the field and removing the "entire query as series name for group-less queries" behavior.

The overall effect of this for a dashboard which previously looked like this:

<img width="1656" alt="Screen Shot 2023-03-20 at 8 08 46 PM" src="https://user-images.githubusercontent.com/8461733/226514846-d8909464-a78a-40fd-8693-f06d65397c61.png">

Is an update to look like this:

<img width="1661" alt="Screen Shot 2023-03-20 at 8 27 35 PM" src="https://user-images.githubusercontent.com/8461733/226514866-fae608b2-2187-4fc7-ab19-a8aaab4131e6.png">

## Improvements

At first glance the update has less info and may seem like a step backward, but the update enables some important workflows.

1 - Charts with multiple queries can be labeled as expected, using something semantic like an alias for the metric name of the query:

![2023-03-20 20 27 01](https://user-images.githubusercontent.com/8461733/226515026-3e384492-9b0f-4163-b3cc-0ab82e1e9dd5.gif)

2 - Joins can be labeled as expected, using something semantic for the join:

![2023-03-20 20 33 14](https://user-images.githubusercontent.com/8461733/226515216-86522233-69c1-4bb2-a565-f866482cd98e.gif)

## Future improvements

This update uses the alphabetical query letter as the default series name, but a follow up enhancement to this could use the metric name for any group-less non-join queries to provide a more meaningful default.


