### PR TITLE
Update: Improve query name override to work with group labels

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -114,12 +114,12 @@ export class QueryEditor extends PureComponent<Props, QueryEditorState> {
             onToggle={() => this.setState({ isOptionsOpen: !this.state.isOptionsOpen })}
           >
             <Field
-              label="Legend"
-              description="Series name override or template. Ex. {{hostname}} will be replaced with label value for hostname."
+              label="Query name"
+              description="Display name for the query, shown with each series in the chart tooltip and legend"
             >
               <Input
                 css
-                name="legendFormat"
+                name="queryName"
                 spellCheck="false"
                 onChange={this.onChangeFormat}
                 value={this.props.query.format}


### PR DESCRIPTION
## What does this PR do?

Updates the plugin to improve custom display names for queries, including:

1. Fix a bug where setting a query name caused the group by labels to dissapear
2. Update the input name and description to be more accurate

## Why are you doing it?

Currently if you try to use the Legend configuration for a query, the results are inconsistent and disappointing. If your query has group by values then the Legend name will cause those labels to disappear:

![2023-03-20 21 01 21](https://user-images.githubusercontent.com/8461733/228055888-aff652de-eb93-49c2-b7be-69df751bdf5a.gif)

This update fixes that issue so that custom query names work consistently for queries with and without group by labels:

![2023-03-27 10 48 50](https://user-images.githubusercontent.com/8461733/228056104-49b46184-81f9-4b83-9ec5-741504a0d1dc.gif)

![2023-03-27 10 49 21](https://user-images.githubusercontent.com/8461733/228056110-2ab646f0-0cf9-473f-8471-ff0d5085cf5a.gif)

