### PR TITLE
Chore: Update development Grafana image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   grafana:
-    image: grafana/grafana-oss:8.2.6
+    image: grafana/grafana-oss:8.5.22
     container_name: grafana
     ports:
       - 3000:3000


### PR DESCRIPTION
PR updates the development Grafana image version to latest v8 release. This resolves an issue making the QueryField mostly unusable in local development.

ref: https://github.com/grafana/grafana/issues/54535