### PR TITLE
Update: Add UQL Reference link badge

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -63,7 +63,7 @@ export class QueryEditor extends PureComponent<Props, State> {
             color="blue"
             icon="external-link-alt"
             text={
-              <a href="https://docs.lightstep.com/docs/uql-reference" target="_blank">
+              <a href="https://docs.lightstep.com/docs/uql-cheatsheet" target="_blank">
                 UQL Reference
               </a>
             }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import defaults from 'lodash/defaults';
-import { QueryField, Select, Field, Input, Collapse } from '@grafana/ui';
+import { QueryField, Select, Field, Input, Collapse, Badge } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from '../datasource';
 import { LightstepDataSourceOptions, LightstepQuery } from '../types';
@@ -58,6 +58,18 @@ export class QueryEditor extends PureComponent<Props, State> {
 
     return (
       <div>
+        <div className="gf-form">
+          <Badge
+            color="blue"
+            icon="external-link-alt"
+            text={
+              <a href="https://docs.lightstep.com/docs/uql-reference" target="_blank">
+                UQL Reference
+              </a>
+            }
+            style={{ marginLeft: 'auto' }}
+          />
+        </div>
         <div className="gf-form">
           {projects.length > 1 && (
             <Select

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -63,7 +63,7 @@ export class QueryEditor extends PureComponent<Props, State> {
             color="blue"
             icon="external-link-alt"
             text={
-              <a href="https://docs.lightstep.com/docs/uql-cheatsheet" target="_blank">
+              <a href="https://docs.lightstep.com/docs/uql-cheatsheet" target="_blank" rel="noreferrer">
                 UQL Reference
               </a>
             }


### PR DESCRIPTION
## Overview

Adds a badge to the query editor UI that links to the UQL docs to provide helpful language reference material.

![Screen Shot 2023-04-14 at 8 34 46 AM](https://user-images.githubusercontent.com/8461733/232092919-e1c4ecb9-f1fd-498e-90b8-dc740fe2f51a.png)
